### PR TITLE
Allow adding extra config for lighthouse node

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,7 @@ nebula_lighthouse_hostname: lighthouse
 nebula_lighthouse_internal_ip_addr: 192.168.77.1
 nebula_lighthouse_public_hostname: my-nebula-server.com
 nebula_lighthouse_public_port: 4242
+nebula_lighthouse_extra_config: {}
 
 nebula_inbound_rules:
   - { port: "any", proto: "any", host: "any" }

--- a/templates/lighthouse_config.yml.j2
+++ b/templates/lighthouse_config.yml.j2
@@ -29,6 +29,8 @@ lighthouse:
     #
     # - "192.168.77.1"
 
+  {{ nebula_lighthouse_extra_config | to_nice_yaml | indent(2) }}
+
 listen:
   # 0.0.0.0 means "all interfaces," which is probably what you want
   #


### PR DESCRIPTION
This PR adds the optional variable `nebula_lighthouse_extra_config`. This can be used to add extra config to the lighthouse node's config, located at `/opt/nebula/config.yml`. 

## For Example

This variable defined for the lighthouse node...
```
nebula_lighthouse_extra_config:
  serve_dns: true
  dns:
    host: "{{ nebula_lighthouse_internal_ip_addr }}"
    port: 53
```

...will produce the following config in `/opt/nebula/config.yml` on the lighthouse, under the "lighthouse" key.
```
[...]
lighthouse:
  interval: 60

  # if you're a lighthouse, say you're a lighthouse
  #
  am_lighthouse: true

  hosts:
    # If you're a lighthouse, this section should be EMPTY
    # or commented out. If you're NOT a lighthouse, list
    # lighthouse nodes here, one per line, in the following
    # format:
    #
    # - "192.168.77.1"

  dns:
      host: 10.66.0.1
      port: 53
  serve_dns: true
[...]
```