### PR TITLE
Allow override of nebula check minute

### DIFF
--- a/tasks/node.yml
+++ b/tasks/node.yml
@@ -76,6 +76,6 @@
 - name: Ensure nebula-check is scheduled via cron
   cron:
     name: "nebula-check"
-    minute: "*/5"
+    minute: "{{ nebula_check_cron_minute | default('*/5') }}"
     job: "/opt/nebula/nebula-check.sh"
   when: nebula_install_check_cron|bool


### PR DESCRIPTION
The nebula-check cron job can now be modified by setting the `nebula_check_cron_minute` variable, which will change the `minute` interval for the cron job. It defaults to `*/5`.