### PR TITLE
Version Bump, Lighthouse Relay, Systemd Unit Changes, Prometheus Metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ backup01.company.com nebula_internal_ip_addr=10.43.0.5
 pbx01.company.com nebula_internal_ip_addr=10.43.0.6
 ```
 
+**Note:** More variables can be found in the [role defaults.](defaults/main.yml)
+
 # Running the Playbook
 ```
 ansible-playbook -i inventory nebula.yml

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ You can read more about Nebula [on the official repo](https://github.com/slackhq
   user: ansible
   become: yes
   vars:
-    nebula_version: 1.4.0
+    nebula_version: 1.8.0
     nebula_network_name: "Company Nebula Mgmt Net"
     nebula_network_cidr: 16
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,7 @@ nebula_client_cert_duration: "43800h0m0s" #5 years
 nebula_clean_install: false
 nebula_lighthouse_build_hosts_file: true
 nebula_node_lighthouse_in_hosts_file: true
+nebula_node_use_lighthouse_as_relay: true
 nebula_install_check_cron: true
 
 
@@ -13,6 +14,7 @@ nebula_lighthouse_hostname: lighthouse
 nebula_lighthouse_internal_ip_addr: 192.168.77.1
 nebula_lighthouse_public_hostname: my-nebula-server.com
 nebula_lighthouse_public_port: 4242
+nebula_lighthouse_is_relay: true
 nebula_lighthouse_extra_config: {}
 
 nebula_firewall_block_action: drop

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,4 @@
-nebula_version: 1.7.1
+nebula_version: 1.8.0
 nebula_network_name: "My Nebula Mesh Network"
 nebula_network_cidr: 24
 nebula_ca_cert_duration: "87600h0m0s" #10 years

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,6 +17,12 @@ nebula_lighthouse_public_port: 4242
 nebula_lighthouse_is_relay: true
 nebula_lighthouse_extra_config: {}
 
+nebula_metrics_prometheus_enabled: false
+nebula_metrics_prometheus_listen: "127.0.0.1:4244"
+nebula_metrics_prometheus_path: "/metrics"
+nebula_metrics_prometheus_namespace: nebula
+nebula_metrics_prometheus_interval: 10s
+
 nebula_firewall_block_action: drop
 
 nebula_inbound_rules:

--- a/templates/lighthouse.service.j2
+++ b/templates/lighthouse.service.j2
@@ -1,12 +1,13 @@
 [Unit]
-Description=Nebula Lighthouse
-Wants=basic.target
-After=basic.target network.target
+Description=Nebula overlay networking tool - Lighthouse
+Wants=basic.target network-online.target nss-lookup.target time-sync.target
+After=basic.target network.target network-online.target
+Before=sshd.service
 
 [Service]
+Type=notify
+NotifyAccess=main
 SyslogIdentifier=nebula
-StandardOutput=syslog
-StandardError=syslog
 ExecReload=/bin/kill -HUP $MAINPID
 ExecStart=/opt/nebula/nebula -config /opt/nebula/config.yml
 Restart=always
@@ -14,3 +15,4 @@ RestartSec=42s
 
 [Install]
 WantedBy=multi-user.target
+

--- a/templates/lighthouse_config.yml.j2
+++ b/templates/lighthouse_config.yml.j2
@@ -68,6 +68,15 @@ logging:
   level: info
   format: text
 
+{% if nebula_metrics_prometheus_enabled %}
+stats:
+  type: prometheus
+  listen: {{ nebula_metrics_prometheus_listen }}
+  path: {{ nebula_metrics_prometheus_path }}
+  namespace: {{ nebula_metrics_prometheus_namespace }}
+  interval: {{ nebula_metrics_prometheus_interval }}
+{% endif %}
+
 # you NEED this firewall section.
 #
 # Nebula has its own firewall in addition to anything

--- a/templates/lighthouse_config.yml.j2
+++ b/templates/lighthouse_config.yml.j2
@@ -49,6 +49,10 @@ punchy: true
 #
 punch_back: true
 
+relay:
+  am_relay: {{ nebula_lighthouse_is_relay }}
+  use_relays: false
+
 tun:
   # sensible defaults. don't monkey with these unless
   # you're CERTAIN you know what you're doing.
@@ -74,8 +78,8 @@ logging:
 # one node from another.
 #
 firewall:
-  outbound_action: {{ nebula_firewall_block_action | default('drop') }}
-  inbound_action: {{ nebula_firewall_block_action | default('drop') }}
+  outbound_action: {{ nebula_firewall_block_action }}
+  inbound_action: {{ nebula_firewall_block_action }}
   conntrack:
     tcp_timeout: 120h
     udp_timeout: 3m

--- a/templates/node.service.j2
+++ b/templates/node.service.j2
@@ -1,12 +1,13 @@
 [Unit]
-Description=nebula
-Wants=basic.target
-After=basic.target network.target
+Description=Nebula overlay networking tool
+Wants=basic.target network-online.target nss-lookup.target time-sync.target
+After=basic.target network.target network-online.target
+Before=sshd.service
 
 [Service]
+Type=notify
+NotifyAccess=main
 SyslogIdentifier=nebula
-StandardOutput=syslog
-StandardError=syslog
 ExecReload=/bin/kill -HUP $MAINPID
 ExecStart=/opt/nebula/nebula -config /opt/nebula/config.yml
 Restart=always

--- a/templates/node_config.yml.j2
+++ b/templates/node_config.yml.j2
@@ -40,6 +40,12 @@ listen:
 #
 punchy: true
 
+relay:
+  am_relay: false
+  use_relays: {{ nebula_node_use_lighthouse_as_relay }}
+  relays:
+    - {{ nebula_lighthouse_internal_ip_addr }}
+
 # "punch_back" allows the other node to try punching out to you,
 # if you're having trouble punching out to it. Useful for stubborn
 # networks with symmetric NAT, etc.
@@ -71,8 +77,8 @@ logging:
 # one node from another.
 #
 firewall:
-  outbound_action: {{ nebula_firewall_block_action | default('drop') }}
-  inbound_action: {{ nebula_firewall_block_action | default('drop') }}
+  outbound_action: {{ nebula_firewall_block_action }}
+  inbound_action: {{ nebula_firewall_block_action }}
   conntrack:
     tcp_timeout: 120h
     udp_timeout: 3m

--- a/templates/node_config.yml.j2
+++ b/templates/node_config.yml.j2
@@ -67,6 +67,15 @@ logging:
   level: info
   format: text
 
+{% if nebula_metrics_prometheus_enabled %}
+stats:
+  type: prometheus
+  listen: {{ nebula_metrics_prometheus_listen }}
+  path: {{ nebula_metrics_prometheus_path }}
+  namespace: {{ nebula_metrics_prometheus_namespace }}
+  interval: {{ nebula_metrics_prometheus_interval }}
+{% endif %}
+
 # you NEED this firewall section.
 #
 # Nebula has its own firewall in addition to anything


### PR DESCRIPTION
This PR:
- Updates Nebula to version 1.8.0 by default
- Adds Prometheus metrics (disabled by default)
- Introduces lighthouse relay functionality (enabled by default)
- Updates systemd service unit files to match latest examples from Slackhq