### PR TITLE
Check for Duplicate IP Addresses

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,7 +4,10 @@
     - name: Uninstall Nebula (clean install)
       include_tasks: uninstall.yml
       when: nebula_clean_install|bool
-    
+
+    - name: Preflight checks
+      include_tasks: preflight.yml
+
     - name: Install Nebula on all hosts 
       include_tasks: nebula.yml
     

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -1,0 +1,22 @@
+---
+- name: Preflight checks
+  block:
+    - name: Collecting all nebula_internal_ip_addr values
+      set_fact:
+        sorted_ips: "{{ hostvars | map('extract', hostvars, ['nebula_internal_ip_addr']) | list | sort }}"
+
+    - name: Initialize duplicated_ips list
+      set_fact:
+        duplicated_ips: []
+
+    - name: Looking for duplicate IP addresses
+      set_fact:
+        duplicated_ips: "{{ duplicated_ips + [item] }}"
+      loop: "{{ sorted_ips | unique }}"
+      when: "sorted_ips | select('equalto', item) | list | length > 1"
+
+    - name: Fail if duplicate IP addresses are found
+      fail:
+        msg: "You have one or more hosts with duplicate IP addresses assigned: {{ duplicated_ips }}"
+      when: duplicated_ips | length > 0
+  run_once: true


### PR DESCRIPTION
Add a `preflight.yml` task file that includes an early check to make sure you don't have hosts with duplicate Nebula IP addresses assigned, which can cause strange issues that are hard to trace down