### PR TITLE
preflight: check that the var is defined for the host before adding it to a map

### DIFF
--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -3,7 +3,14 @@
   block:
     - name: Collecting all nebula_internal_ip_addr values
       set_fact:
-        sorted_ips: "{{ hostvars | map('extract', hostvars, ['nebula_internal_ip_addr']) | list | sort }}"
+        sorted_ips: >-
+          {{ hostvars
+             | dict2items
+             | selectattr('value.nebula_internal_ip_addr', 'defined')
+             | map(attribute='value.nebula_internal_ip_addr')
+             | list
+             | sort
+          }}
 
     - name: Initialize duplicated_ips list
       set_fact:


### PR DESCRIPTION
This change is because items in the inventory with no `nebula_internal_ip_addr` defined would cause this error:

```
"msg": "The task includes an option with an undefined variable. The error was: 'ansible.vars.hostvars.HostVarsVars object' has no attribute 'nebula_internal_ip_addr'. 'ansible.vars.hostvars.HostVarsVars object' has no attribute 'nebula_internal_ip_addr'\n\nThe error appears to be in '/opt/ansible/.ansible/roles/nebula/tasks/preflight.yml': line 4, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n  block:\n    - name: Collecting all nebula_internal_ip_addr values
```