### PR TITLE
Add automated IP assignment and Cloudflare DNS integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ You can read more about Nebula [on the official repo](https://github.com/slackhq
 ```
 
 # Example Inventory
+## Traditional Method (Manual IP Assignment)
 ```
 [nebula_lighthouse]
 lighthouse01.company.com
@@ -50,9 +51,87 @@ backup01.company.com nebula_internal_ip_addr=10.43.0.5
 pbx01.company.com nebula_internal_ip_addr=10.43.0.6
 ```
 
+## Automatic IP Assignment
+With automatic IP assignment, you can organize hosts into groups without having to specify IPs:
+
+```
+[nebula_lighthouse]
+lighthouse01.company.com
+
+[webservers]
+web01.company.com
+web02.company.com
+web03.company.com
+
+[databases]
+db01.company.com
+db02.company.com
+
+[app_servers]
+app01.company.com
+app02.company.com
+```
+
+IPs will be automatically assigned based on the group mapping defined in `nebula_ip_map`. 
+By default, the following mapping is used:
+
+```yaml
+nebula_ip_map:
+  nebula_lighthouse: {prefix: "10.43.0", start: 1}  # 10.43.0.1, 10.43.0.2, etc.
+  webservers: {prefix: "10.43.1", start: 10}        # 10.43.1.10, 10.43.1.11, etc.
+  databases: {prefix: "10.43.2", start: 10}         # 10.43.2.10, 10.43.2.11, etc.
+  app_servers: {prefix: "10.43.3", start: 10}       # 10.43.3.10, 10.43.3.11, etc.
+  monitoring: {prefix: "10.43.4", start: 10}        # 10.43.4.10, 10.43.4.11, etc.
+  backups: {prefix: "10.43.5", start: 10}           # 10.43.5.10, 10.43.5.11, etc.
+```
+
+You can customize this mapping in your playbook variables. If a host isn't in a mapped group, it will use a fallback hash-based IP in the 10.43.254.x range.
+
 **Note:** More variables can be found in the [role defaults.](defaults/main.yml)
+
+# Cloudflare DNS Integration
+
+This role can automatically create DNS records in Cloudflare for your Nebula nodes:
+
+1. Enable the integration in your inventory:
+```yaml
+nebula_cloudflare_integration: true
+nebula_cloudflare_zone: "example.com"
+```
+
+2. Store your Cloudflare API token securely in your vault file:
+```yaml
+nebula_cloudflare_api_token: "your-cloudflare-api-token"
+```
+
+3. Customize DNS naming convention:
+```yaml
+# Default: hostname-neb.example.com (nh-web01-neb.example.com)
+nebula_dns_affix: "neb"
+nebula_dns_affix_position: "suffix"  # Options: "suffix" or "prefix"
+nebula_dns_affix_separator: "-"
+
+# For prefix style: neb-hostname.example.com (neb-nh-web01.example.com)
+nebula_dns_affix: "neb"
+nebula_dns_affix_position: "prefix"
+nebula_dns_affix_separator: "-"
+```
+
+4. Additional DNS settings:
+```yaml
+nebula_cloudflare_ttl: 120
+nebula_cloudflare_proxied: false
+```
+
+The role creates A records for each Nebula host using your chosen naming convention, pointing to the host's Nebula internal IP. This makes it easy to address Nebula hosts by DNS name from anywhere with access to your DNS.
 
 # Running the Playbook
 ```
 ansible-playbook -i inventory nebula.yml
+```
+
+# DNS-only Update
+To update only DNS records without modifying the Nebula installation:
+```
+ansible-playbook -i inventory nebula.yml --tags nebula_dns
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,29 @@ nebula_node_lighthouse_in_hosts_file: true
 nebula_node_use_lighthouse_as_relay: true
 nebula_install_check_cron: true
 
+# IP Assignment Configuration
+nebula_network_prefix: "10.43"
+# Default mapping for Nebula IP assignments if none provided
+nebula_ip_map:
+  nebula_lighthouse: {prefix: "10.43.0", start: 1}
+  webservers: {prefix: "10.43.1", start: 10}
+  databases: {prefix: "10.43.2", start: 10}
+  app_servers: {prefix: "10.43.3", start: 10}
+  monitoring: {prefix: "10.43.4", start: 10}
+  backups: {prefix: "10.43.5", start: 10}
+
+# Cloudflare DNS Integration (disabled by default)
+nebula_cloudflare_integration: false
+# nebula_cloudflare_api_token: ""  # Set in vault files
+# nebula_cloudflare_zone: "example.com"  # Your Cloudflare DNS zone
+
+# DNS naming configuration
+nebula_dns_affix: "neb"  # The text to add to the hostname
+nebula_dns_affix_position: "suffix"  # Options: "prefix", "suffix"
+nebula_dns_affix_separator: "-"  # Separator between hostname and affix
+
+nebula_cloudflare_ttl: 120  # TTL in seconds
+nebula_cloudflare_proxied: false  # Whether to proxy records through Cloudflare
 
 nebula_lighthouse_hostname: lighthouse
 nebula_lighthouse_internal_ip_addr: 192.168.77.1

--- a/tasks/cloudflare_dns.yml
+++ b/tasks/cloudflare_dns.yml
@@ -1,0 +1,47 @@
+---
+# Tasks for creating Cloudflare DNS entries for Nebula hosts
+
+- name: Check if Cloudflare credentials are defined
+  ansible.builtin.assert:
+    that:
+      - nebula_cloudflare_api_token is defined
+      - nebula_cloudflare_zone is defined
+    fail_msg: "Cloudflare API token and zone must be defined for DNS integration"
+    quiet: true
+  when: nebula_cloudflare_integration|bool
+
+- name: Extract hostname without domain for DNS record creation
+  ansible.builtin.set_fact:
+    nebula_hostname_base: "{{ inventory_hostname | regex_replace('\\..*$', '') }}"
+  when: nebula_cloudflare_integration|bool
+
+- name: Create DNS record name with affix as suffix
+  ansible.builtin.set_fact:
+    nebula_dns_record: "{{ nebula_hostname_base }}{{ nebula_dns_affix_separator }}{{ nebula_dns_affix }}"
+  when: 
+    - nebula_cloudflare_integration|bool
+    - nebula_dns_affix_position == "suffix"
+
+- name: Create DNS record name with affix as prefix
+  ansible.builtin.set_fact:
+    nebula_dns_record: "{{ nebula_dns_affix }}{{ nebula_dns_affix_separator }}{{ nebula_hostname_base }}"
+  when: 
+    - nebula_cloudflare_integration|bool
+    - nebula_dns_affix_position == "prefix"
+
+- name: Create/Update Cloudflare DNS A record for Nebula internal IP
+  community.general.cloudflare_dns:
+    zone: "{{ nebula_cloudflare_zone }}"
+    api_token: "{{ nebula_cloudflare_api_token }}"
+    type: A
+    record: "{{ nebula_dns_record }}"
+    value: "{{ nebula_internal_ip_addr }}"
+    state: present
+    proxied: "{{ nebula_cloudflare_proxied|default(false) }}"
+    ttl: "{{ nebula_cloudflare_ttl|default(120) }}"
+  delegate_to: localhost
+  become: false
+  when: nebula_cloudflare_integration|bool
+  tags:
+    - nebula_dns
+    - nebula_cloudflare

--- a/tasks/ip_assignment.yml
+++ b/tasks/ip_assignment.yml
@@ -1,0 +1,38 @@
+---
+# Tasks for automatic Nebula IP assignment
+
+- name: Check if nebula_internal_ip_addr is explicitly defined
+  set_fact:
+    nebula_ip_is_explicit: "{{ nebula_internal_ip_addr is defined }}"
+
+- name: Determine host's primary group for IP assignment
+  set_fact:
+    nebula_primary_group: "{{ group_names | intersect(nebula_ip_map.keys() | list) | first | default('undefined') }}"
+  when: not nebula_ip_is_explicit|bool
+
+- name: Warn if host not in a mapped group and IP not explicitly set
+  ansible.builtin.debug:
+    msg: >
+      WARNING: Host {{ inventory_hostname }} is not in any of the mapped groups for IP assignment
+      and doesn't have nebula_internal_ip_addr explicitly set. Using fallback method.
+  when: not nebula_ip_is_explicit|bool and nebula_primary_group == 'undefined'
+
+- name: Calculate IP from group mapping (when in mapped group)
+  set_fact:
+    nebula_group_info: "{{ nebula_ip_map[nebula_primary_group] }}"
+    nebula_host_index: "{{ groups[nebula_primary_group].index(inventory_hostname) }}"
+  when: not nebula_ip_is_explicit|bool and nebula_primary_group != 'undefined'
+
+- name: Assign IP based on group mapping
+  set_fact:
+    nebula_internal_ip_addr: "{{ nebula_group_info.prefix }}.{{ nebula_group_info.start|int + nebula_host_index|int }}"
+  when: not nebula_ip_is_explicit|bool and nebula_primary_group != 'undefined'
+
+- name: Fallback IP assignment using hash (when not in mapped group and no explicit IP)
+  set_fact:
+    nebula_internal_ip_addr: "{{ nebula_network_prefix }}.254.{{ (inventory_hostname | hash('md5') | int(0, 16) % 253) + 1 }}"
+  when: not nebula_ip_is_explicit|bool and nebula_primary_group == 'undefined'
+
+- name: Display assigned Nebula IP
+  ansible.builtin.debug:
+    msg: "Host {{ inventory_hostname }} assigned Nebula IP: {{ nebula_internal_ip_addr }} (Method: {{ 'Explicit' if nebula_ip_is_explicit else 'Group-based' if nebula_primary_group != 'undefined' else 'Hash-based' }})"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
+- name: Handle Nebula IP assignment
+  include_tasks: ip_assignment.yml
+
 - name: Nebula Install
   block:
     - name: Uninstall Nebula (clean install)
@@ -18,4 +21,10 @@
     - name: Deploy Nebula Node
       include_tasks: node.yml
       when: inventory_hostname not in groups['nebula_lighthouse']
-  when: inventory_hostname in groups['nebula_lighthouse'] or nebula_internal_ip_addr is defined
+
+- name: Configure Cloudflare DNS for Nebula hosts
+  include_tasks: cloudflare_dns.yml
+  when: nebula_cloudflare_integration|bool
+  tags:
+    - nebula_dns
+    - nebula_cloudflare


### PR DESCRIPTION
added automatic ip assignment and integration with cloudflare 

the cloudflare option is a boolean you can choose to use it or not. 
The automatic ip assignment is backward compatible with the current styling for ip assignments. 

I know we discussed about cloudflare being out of scope for the role, this PR is just in case you want some of the changes. I can close if you want. 